### PR TITLE
Pass in empty string in case variable is not set.

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -19,10 +19,10 @@ if (NOT ASSETS_DIR)
     set(ASSETS_DIR "" CACHE PATH "Data and images required for some examples (url: https://github.com/arrayfire/assets)")
 endif (NOT ASSETS_DIR)
 
-file(TO_NATIVE_PATH ${ASSETS_DIR} ASSETS_DIR)
+file(TO_NATIVE_PATH "${ASSETS_DIR}" ASSETS_DIR)
 
 if(WIN32)
-  string(REPLACE "\\" "\\\\" ASSETS_DIR  ${ASSETS_DIR})
+  string(REPLACE "\\" "\\\\" ASSETS_DIR "${ASSETS_DIR}")
   add_definitions(-DWIN32_LEAN_AND_MEAN)
   unset(CMAKE_RUNTIME_OUTPUT_DIRECTORY)
 endif()


### PR DESCRIPTION
CMake configuration currently fails when ASSETS_DIR is emtpy.