### PR TITLE
Update vcpkg.json

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -83,5 +83,5 @@
             ]
         }
     },
-    "builtin-baseline": "f14984af3738e69f197bf0e647a8dca12de92996"
+    "builtin-baseline": "ad3bae57455a3c3ce528fcd47d8e8027d0498add"
 }


### PR DESCRIPTION
Updated built in baseline hash ID with functional on. Was receiving error for Jasper library build. Replaced with correct ID



### Short description of change.
Changed build in baseline ID in vcpkg json file

Description
-----------

Additional information about the PR answering following questions:

* This is a bug fix
* There was an issue with vcpkg build of dependency: Jasper in visual studio 2022;
* Without this change user won't be able to build the library.
* There is not potential impact on hardware or software
* There is no new functions or their functionality added in this PR.
* Maybe this can be backported to older version since vcpkg keeps updating their baseline json.

